### PR TITLE
add dependency to libraw

### DIFF
--- a/emby-server.json
+++ b/emby-server.json
@@ -17,6 +17,7 @@
     "multimedia/libva",
     "audio/libvorbis",
     "graphics/webp",
+    "graphics/libraw",
     "multimedia/libx264",
     "devel/libzvbi"
   ],


### PR DESCRIPTION
I just tried installing the package on FreeNAS-11.2-U2.1. The post-install step adding the 4.0.2.0 package breaks because `libraw` is required bot not installed.